### PR TITLE
fix(pool): adding async started checks to prevent race conditions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,15 @@ linters:
     - iface
     - thelper
     - tparallel
+    - intrange
+    - testifylint
+    - perfsprint
+issues:
+  exclude-rules:
+    - path: (.+)_test.go
+      linters:
+        - revive
+      text: "^(enforce-slice-style|enforce-map-style)"
 linters-settings:
   revive:
     # Default: false
@@ -135,3 +144,5 @@ linters-settings:
     enable:
       - identical # Identifies interfaces in the same package that have identical method sets.
       - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.
+  testifylint:
+    enable-all: true

--- a/pool.go
+++ b/pool.go
@@ -34,6 +34,8 @@ type pool struct {
 	// wg is the wait group for the worker pool.
 	wg *sync.WaitGroup
 
+	mut *sync.RWMutex
+
 	// done is the channel to signal the worker pool to stop.
 	done chan struct{}
 
@@ -92,4 +94,18 @@ func New(opts ...WorkerOption) Pool {
 	}
 
 	return p
+}
+
+func (p *pool) setStarted(started bool) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
+	p.started = started
+}
+
+func (p *pool) isStarted() bool {
+	p.mut.RLock()
+	defer p.mut.RUnlock()
+
+	return p.started
 }

--- a/worker.go
+++ b/worker.go
@@ -16,13 +16,13 @@ var (
 
 // start starts the worker pool by deploying the workers to the pool.
 func (p *pool) start() {
-	if p.started {
+	if p.isStarted() {
 		return
 	}
 
-	p.started = true
+	p.setStarted(true)
 	idleWorkers.Set(float64(p.totalWorkers))
-	for i := 0; i < p.totalWorkers; i++ {
+	for range p.totalWorkers {
 		p.wg.Add(1)
 		go p.deployWorker()
 	}
@@ -74,7 +74,7 @@ func (p *pool) Stop() {
 		activeWorkers.Set(0)
 		pendingTasks.Set(0)
 
-		p.started = false
+		p.setStarted(false)
 	}()
 
 	// Clear down the tasks channel while waiting for the workers to finish
@@ -122,7 +122,7 @@ func (p *pool) Schedule(task Runnable) error {
 		return ErrWorkerPoolStopped
 	}
 
-	if p.delayedStart && !p.started {
+	if p.delayedStart && !p.isStarted() {
 		p.start()
 	}
 
@@ -144,7 +144,7 @@ func (p *pool) BlockingSchedule(task Runnable) error {
 		return ErrWorkerPoolStopped
 	}
 
-	if p.delayedStart && !p.started {
+	if p.delayedStart && !p.isStarted() {
 		p.start()
 	}
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to the `.golangci.yaml` configuration and improvements to the `pool` and `worker` structs in the Go codebase. The most important changes focus on adding new linters, configuring linter settings, and enhancing thread safety in the worker pool implementation.

### Linter Configuration Updates:

* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R15-R23): Added new linters `intrange`, `testifylint`, and `perfsprint` to the `linters` section.
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R147-R148): Added exclusion rules for specific linters on test files and enabled all rules for `testifylint`.

### Worker Pool Enhancements:

* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2R37-R38): Introduced a new `mut` field of type `*sync.RWMutex` in the `pool` struct to manage concurrent access.
* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2R98-R111): Added `setStarted` and `isStarted` methods to safely update and check the `started` status of the worker pool using the new mutex.
* [`worker.go`](diffhunk://#diff-0ca2bf28ee146c014db869dd42c216dff322e265933c8b179b939f18016386d6L19-R25): Updated the `start`, `Stop`, `Schedule`, and `BlockingSchedule` methods to use the new `setStarted` and `isStarted` methods for thread-safe operations. [[1]](diffhunk://#diff-0ca2bf28ee146c014db869dd42c216dff322e265933c8b179b939f18016386d6L19-R25) [[2]](diffhunk://#diff-0ca2bf28ee146c014db869dd42c216dff322e265933c8b179b939f18016386d6L77-R77) [[3]](diffhunk://#diff-0ca2bf28ee146c014db869dd42c216dff322e265933c8b179b939f18016386d6L125-R125) [[4]](diffhunk://#diff-0ca2bf28ee146c014db869dd42c216dff322e265933c8b179b939f18016386d6L147-R147)