### PR TITLE
fix(metrics): updating how the metrics are handled for the async counts

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1,9 +1,17 @@
 package workerpool
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
+
+type asyncMetricHandler struct {
+	muxIdleWorkers   *sync.RWMutex
+	muxActiveWorkers *sync.RWMutex
+	muxPendingTasks  *sync.RWMutex
+}
 
 var (
 	// idleWorkers is the number of idle workers in the pool.
@@ -30,3 +38,65 @@ var (
 		Help: "Duration of the task",
 	})
 )
+
+func newAsyncMetricHandler() *asyncMetricHandler {
+	return &asyncMetricHandler{
+		muxIdleWorkers:   new(sync.RWMutex),
+		muxActiveWorkers: new(sync.RWMutex),
+		muxPendingTasks:  new(sync.RWMutex),
+	}
+}
+
+func (h *asyncMetricHandler) incIdleWorkers() {
+	h.muxIdleWorkers.Lock()
+	idleWorkers.Inc()
+	h.muxIdleWorkers.Unlock()
+}
+
+func (h *asyncMetricHandler) decIdleWorkers() {
+	h.muxIdleWorkers.Lock()
+	idleWorkers.Dec()
+	h.muxIdleWorkers.Unlock()
+}
+
+func (h *asyncMetricHandler) setIdleWorkers(value float64) {
+	h.muxIdleWorkers.Lock()
+	idleWorkers.Set(value)
+	h.muxIdleWorkers.Unlock()
+}
+
+func (h *asyncMetricHandler) incActiveWorkers() {
+	h.muxActiveWorkers.Lock()
+	activeWorkers.Inc()
+	h.muxActiveWorkers.Unlock()
+}
+
+func (h *asyncMetricHandler) decActiveWorkers() {
+	h.muxActiveWorkers.Lock()
+	activeWorkers.Dec()
+	h.muxActiveWorkers.Unlock()
+}
+
+func (h *asyncMetricHandler) setActiveWorkers(value float64) {
+	h.muxActiveWorkers.Lock()
+	activeWorkers.Set(value)
+	h.muxActiveWorkers.Unlock()
+}
+
+func (h *asyncMetricHandler) incPendingTasks() {
+	h.muxPendingTasks.Lock()
+	pendingTasks.Inc()
+	h.muxPendingTasks.Unlock()
+}
+
+func (h *asyncMetricHandler) decPendingTasks() {
+	h.muxPendingTasks.Lock()
+	pendingTasks.Dec()
+	h.muxPendingTasks.Unlock()
+}
+
+func (h *asyncMetricHandler) setPendingTasks(value float64) {
+	h.muxPendingTasks.Lock()
+	pendingTasks.Set(value)
+	h.muxPendingTasks.Unlock()
+}

--- a/pool.go
+++ b/pool.go
@@ -36,6 +36,8 @@ type pool struct {
 
 	mut *sync.RWMutex
 
+	metricsHandler *asyncMetricHandler
+
 	// done is the channel to signal the worker pool to stop.
 	done chan struct{}
 
@@ -68,6 +70,7 @@ func New(opts ...WorkerOption) Pool {
 	p := &pool{
 		totalWorkers:   runtime.NumCPU(),
 		maxQueueLength: runtime.NumCPU() * 1000,
+		metricsHandler: newAsyncMetricHandler(),
 		wg:             new(sync.WaitGroup),
 		done:           make(chan struct{}),
 		delayedStart:   false,


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces a new `asyncMetricHandler` to handle metrics in the worker pool more efficiently by using mutex locks to ensure thread safety. The changes primarily focus on refactoring the metric handling code to use this new handler.

### Introduction of `asyncMetricHandler`:

* [`metrics.go`](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R4-R15): Added the `asyncMetricHandler` struct with mutexes for idle workers, active workers, and pending tasks. Implemented methods to increment, decrement, and set these metrics using the new handler. [[1]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R4-R15) [[2]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R41-R102)

### Integration with the worker pool:

* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2R39-R40): Integrated the `asyncMetricHandler` into the pool struct and initialized it in the `New` function. [[1]](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2R39-R40) [[2]](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2R73)
* [`worker.go`](diffhunk://#diff-0ca2bf28ee146c014db869dd42c216dff322e265933c8b179b939f18016386d6L24-R24): Updated the `start`, `deployWorker`, `runTask`, and `Stop` functions to use the new `asyncMetricHandler` methods for metric updates. [[1]](diffhunk://#diff-0ca2bf28ee146c014db869dd42c216dff322e265933c8b179b939f18016386d6L24-R24) [[2]](diffhunk://#diff-0ca2bf28ee146c014db869dd42c216dff322e265933c8b179b939f18016386d6L52-R60) [[3]](diffhunk://#diff-0ca2bf28ee146c014db869dd42c216dff322e265933c8b179b939f18016386d6L73-R75)