### PR TITLE
fix(pool): initalizing the mutex on create

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -34,6 +34,7 @@ type pool struct {
 	// wg is the wait group for the worker pool.
 	wg *sync.WaitGroup
 
+	// mut is the mutex to protect the started flag.
 	mut *sync.RWMutex
 
 	// done is the channel to signal the worker pool to stop.
@@ -69,6 +70,7 @@ func New(opts ...WorkerOption) Pool {
 		totalWorkers:   runtime.NumCPU(),
 		maxQueueLength: runtime.NumCPU() * 1000,
 		wg:             new(sync.WaitGroup),
+		mut:            new(sync.RWMutex),
 		done:           make(chan struct{}),
 		delayedStart:   false,
 		started:        false,

--- a/worker.go
+++ b/worker.go
@@ -38,6 +38,7 @@ func (p *pool) deployWorker() {
 			return
 		case task, ok := <-p.tasks:
 			if !ok {
+				// The tasks channel is closed
 				return
 			}
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to the `pool.go` and `worker.go` files to improve synchronization and add comments for better code clarity. The most important changes include adding a mutex to protect the `started` flag and initializing this mutex in the `New` function.

Improvements to synchronization:

* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2R37): Added a mutex (`mut`) to the `Pool` struct to protect the `started` flag.
* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2R73): Initialized the `mut` mutex in the `New` function to ensure it is ready for use.

Code clarity:

* [`worker.go`](diffhunk://#diff-0ca2bf28ee146c014db869dd42c216dff322e265933c8b179b939f18016386d6R41): Added a comment to explain the scenario when the `tasks` channel is closed in the `deployWorker` function.